### PR TITLE
Run mock inside a PTY

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
+use clap_verbosity_flag::InfoLevel;
 use std::{path::PathBuf, str::FromStr};
 
 #[derive(ValueEnum, Debug, Clone, Copy, Default)]
@@ -58,7 +59,8 @@ pub struct Cli {
     pub config: PathBuf,
 
     #[clap(flatten)]
-    pub verbose: clap_verbosity_flag::Verbosity,
+    // #[clap(default_value = "info")]
+    pub verbose: clap_verbosity_flag::Verbosity<InfoLevel>,
 
     /// Output directory for built packages
     #[clap(short, long, env = "TARGET_DIR", default_value = "anda-build")]

--- a/src/rpm_spec.rs
+++ b/src/rpm_spec.rs
@@ -328,7 +328,7 @@ impl MockBackend {
             cmd.arg("-r").arg(config);
         }
 
-        cmd.arg("--verbose");
+        // cmd.arg("--verbose");
 
         self.extra_repos.iter().for_each(|repo| {
             cmd.arg("-a").arg(repo);
@@ -343,7 +343,7 @@ impl MockBackend {
         });
 
         self.macros.iter().for_each(|(name, value)| {
-            cmd.arg("-D").arg(format!("{name} {value}"));
+            cmd.arg("-D").arg(format!("'{name} {value}'"));
         });
 
         if self.no_mirror {
@@ -498,7 +498,7 @@ impl RPMBuildBackend {
         }
 
         for (name, value) in &self.macros {
-            cmd.arg("-D").arg(format!("{name} {value}"));
+            cmd.arg("-D").arg(format!("'{name} {value}'"));
         }
 
         cmd

--- a/src/util.rs
+++ b/src/util.rs
@@ -105,9 +105,8 @@ impl CommandLog for Command {
 
         // Wrap the command in `script` to force it to give it a TTY
         let mut c = Self::new("script");
-        
-        c
-            .arg("-e")
+
+        c.arg("-e")
             .arg("-f")
             .arg("/dev/null")
             .arg("-q")
@@ -139,10 +138,6 @@ impl CommandLog for Command {
         // handles so we can run both at the same time
         for task in [
             // handle ctrl-c and log
-
-            
-
-
             tokio::spawn(async move {
                 // wait for ctrl-c or child process to finish
 


### PR DESCRIPTION
Fixes a DX issue where we use `mock --verbose` by default, causing logs to be too verbose.

Does this by running mock inside a PTY 