### PR TITLE
feat: add mock no-cleanup options

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     artifacts::Artifacts,
-    cli::{Cli, FlatpakOpts, OciOpts, PackageType, RpmOpts},
+    cli::{Cli, FlatpakOpts, OciOpts, PackageType, RpmOpts, NoMockCleanup},
     cmd,
     flatpak::{FlatpakArtifact, FlatpakBuilder},
     oci::{build_oci, OCIBackend},
@@ -11,6 +11,7 @@ use color_eyre::{eyre::eyre, eyre::Context, Result};
 use itertools::Itertools;
 use std::path::{Path, PathBuf};
 use tracing::{debug, error, info, trace};
+
 
 pub async fn build_rpm(
     opts: &mut RPMOptions,
@@ -305,6 +306,17 @@ pub async fn build_project(
                 rpm_opts.mock_config = Some(mockcfg.to_owned());
             }
             // TODO: Implement global settings
+        }
+
+        if let Some(mock_no_cleanup) = &rbopts.mock_no_cleanup {
+            match mock_no_cleanup {
+                NoMockCleanup::Before => rpm_opts.no_cleanup_before = true,
+                NoMockCleanup::After => rpm_opts.no_cleanup_after = true,
+                NoMockCleanup::All => {
+                    rpm_opts.no_cleanup_before = true;
+                    rpm_opts.no_cleanup_after = true;
+                }
+            }
         }
     }
     let mut arts = Artifacts::new();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,13 @@ pub enum RPMBuilder {
     Rpmbuild,
 }
 
+#[derive(ValueEnum, Debug, Clone, Copy)]
+pub enum NoMockCleanup {
+    Before,
+    After,
+    All,
+}
+
 #[derive(Copy, Clone, ValueEnum, Debug)]
 pub enum PackageType {
     Rpm,
@@ -133,6 +140,10 @@ pub struct RpmOpts {
     /// RPM: Extra repositories to pass to mock
     #[clap(long, short = 'R')]
     pub extra_repos: Vec<String>,
+
+    /// RPM: Whether to clean up a mock chroot and when
+    #[clap(long)]
+    pub mock_no_cleanup: Option<NoMockCleanup>,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/src/rpm_spec.rs
+++ b/src/rpm_spec.rs
@@ -46,6 +46,9 @@ pub struct RPMOptions {
     pub scm_opts: Vec<String>,
     /// Plugin Options (mock)
     pub plugin_opts: Vec<String>,
+    /// Cleanup Options (mock)
+    pub no_cleanup_before: bool,
+    pub no_cleanup_after: bool,
 }
 
 impl RPMOptions {
@@ -64,6 +67,8 @@ impl RPMOptions {
             scm_enable: false,
             scm_opts: Vec::new(),
             plugin_opts: Vec::new(),
+            no_cleanup_before: false,
+            no_cleanup_after: false,
         }
     }
     pub fn add_extra_repo(&mut self, repo: String) {
@@ -158,6 +163,8 @@ impl RPMBuilder {
             mock.enable_scm(options.scm_enable);
             mock.extend_scm_opts(take(&mut options.scm_opts));
             mock.plugin_opts(take(&mut options.plugin_opts));
+            mock.enable_no_cleanup_before(options.no_cleanup_before);
+            mock.enable_no_cleanup_after(options.no_cleanup_after);
 
             mock.build(spec).await
         } else {
@@ -261,6 +268,8 @@ pub struct MockBackend {
     scm_opts: Vec<String>,
     plugin_opts: Vec<String>,
     target: Option<String>,
+    no_cleanup_before: bool,
+    no_cleanup_after: bool,
 }
 
 impl RPMExtraOptions for MockBackend {
@@ -303,6 +312,8 @@ impl MockBackend {
             scm_opts: Vec::new(),
             plugin_opts: Vec::new(),
             target: None,
+            no_cleanup_before: false,
+            no_cleanup_after: false,
         }
     }
 
@@ -335,6 +346,14 @@ impl MockBackend {
 
     pub fn plugin_opts(&mut self, opts: Vec<String>) {
         self.plugin_opts.extend(opts);
+    }
+
+    pub const fn enable_no_cleanup_before(&mut self, enable: bool) {
+        self.no_cleanup_before = enable;
+    }
+
+    pub const fn enable_no_cleanup_after(&mut self, enable: bool) {
+        self.no_cleanup_after = enable;
     }
 
     pub fn target(&mut self, target: Option<String>) {
@@ -385,6 +404,14 @@ impl MockBackend {
         self.scm_opts.iter().for_each(|scm| {
             cmd.arg("--scm-option").arg(scm);
         });
+
+        if self.no_cleanup_before {
+            cmd.arg("--no-clean");
+        }
+
+        if self.no_cleanup_after {
+            cmd.arg("--no-cleanup-after");
+        }
 
         cmd
     }


### PR DESCRIPTION
Sometimes a mock build fails and you would like to see why and using rpmbuild isn't an option without replacing already installed system package.

Mock already provides the `--no-clean` and `--no-cleanup-after` flags which prevent cleaning before and after the mock chroot was used, its then possible to enter a given chroot using `mock --shell`.

I've modeled the CLI option after fedpkg which implements an additional `--no-clean-all` which just enables both of the option.

Probably some ugly things to cleanup but it works:tm: