### PR TITLE
feat: Add new Forgejo update functions

### DIFF
--- a/andax/fns/tsunagu.rs
+++ b/andax/fns/tsunagu.rs
@@ -352,6 +352,33 @@ pub mod ar {
         Ok(latest_version.to_string())
     }
 
+    #[rhai_fn(return_raw, global)]
+    pub fn forgejo(ctx: NativeCallContext, host: &str, repo: &str) -> Res<String> {
+        let req = AGENT.get(&format!("https://{host}/api/v1/repos/{repo}/releases/latest"));
+        let v: Value = req.call().ehdl(&ctx)?.into_body().read_json().ehdl(&ctx)?;
+        trace!("Got json from {repo} hosted with Forgejo:\n{v}");
+        Ok(v["tag_name"].as_str().unwrap_or("").to_owned())
+    }
+
+    #[rhai_fn(return_raw, global)]
+    pub fn forgejo_tag(ctx: NativeCallContext, host: &str, repo: &str) -> Res<String> {
+        let req = AGENT.get(&format!("https://{host}/api/v1/repos/{repo}/tags"));
+        let v: Value = req.call().ehdl(&ctx)?.into_body().read_json().ehdl(&ctx)?;
+        trace!("Got json from {repo} hosted with Forgejo:\n{v}");
+        let v = (v.as_array())
+            .ok_or_else(|| E::from("forgejo_tag received not array"))
+            .map(|a| a.first().ok_or_else(|| E::from("forgejo_tag no tags")))??;
+        Ok(v["name"].as_str().unwrap_or("").to_owned())
+    }
+
+    #[rhai_fn(return_raw, global)]
+    pub fn forgejo_commit(ctx: NativeCallContext, host: &str, repo: &str) -> Res<String> {
+        let req = AGENT.get(&format!("https://{host}/api/v1/repos/{repo}/commits?limit=1"));
+        let v: Value = req.call().ehdl(&ctx)?.into_body().read_json().ehdl(&ctx)?;
+        trace!("Got json from {repo} hosted with Forgejo:\n{v}");
+        Ok(v[0]["sha"].as_str().unwrap_or("").to_owned())
+    }
+
     #[rhai_fn(skip)]
     pub fn internal_env(key: &str) -> Res<String> {
         trace!("env(`{key}`) = {:?}", std::env::var(key));

--- a/tests/test.rhai
+++ b/tests/test.rhai
@@ -31,6 +31,10 @@ print(env("PATH"));
 
 // print(gnome_extensions("live-lockscreen@nick-redwill"));
 
+// print(forgejo("forgejo.ellis.link", "continuwuation/continuwuity"));
+// print(forgejo_tag("forgejo.ellis.link", "continuwuation/continuwuity"));
+// print(forgejo_commit("forgejo.ellis.link", "continuwuation/continuwuity"));
+
 let obj = #{
     "a": 1,
     "b": 2 ,


### PR DESCRIPTION
- Virtually identical to the Gitea update functions.
- These functions are here in case Forgejo's API ever truly splits from Gitea's.
- Add test calls.

Addresses an item listed in the following issue: #440