### PR TITLE
fix (andax ansible function): return string without `""` wrap, fmt

### DIFF
--- a/andax/fns/tsunagu.rs
+++ b/andax/fns/tsunagu.rs
@@ -353,7 +353,11 @@ pub mod ar {
     }
 
     #[rhai_fn(return_raw, global)]
-    pub fn ansible_galaxy(ctx: NativeCallContext, namespace: &str, collection: &str) -> Res<String> {
+    pub fn ansible_galaxy(
+        ctx: NativeCallContext,
+        namespace: &str,
+        collection: &str,
+    ) -> Res<String> {
         let response =
             AGENT.get(&format!("https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/{namespace}/{collection}/versions/?limit=1&ordering=-version"))
                 .header("User-Agent", USER_AGENT)
@@ -363,7 +367,7 @@ pub mod ar {
         let response: Value = response.into_body().read_json().ehdl(&ctx)?;
         Ok(response["data"][0]["version"].as_str().unwrap_or_default().to_owned())
     }
-   
+
     #[rhai_fn(return_raw, global)]
     pub fn forgejo(ctx: NativeCallContext, host: &str, repo: &str) -> Res<String> {
         let req = AGENT.get(&format!("https://{host}/api/v1/repos/{repo}/releases/latest"));

--- a/andax/fns/tsunagu.rs
+++ b/andax/fns/tsunagu.rs
@@ -361,7 +361,7 @@ pub mod ar {
                 .call()
                 .ehdl(&ctx)?;
         let response: Value = response.into_body().read_json().ehdl(&ctx)?;
-        Ok(response["data"][0]["version"].to_string())
+        Ok(response["data"][0]["version"].as_str().unwrap_or_default().to_string())
     }
    
     #[rhai_fn(return_raw, global)]

--- a/andax/fns/tsunagu.rs
+++ b/andax/fns/tsunagu.rs
@@ -361,7 +361,7 @@ pub mod ar {
                 .call()
                 .ehdl(&ctx)?;
         let response: Value = response.into_body().read_json().ehdl(&ctx)?;
-        Ok(response["data"][0]["version"].as_str().unwrap_or_default().to_string())
+        Ok(response["data"][0]["version"].as_str().unwrap_or_default().to_owned())
     }
    
     #[rhai_fn(return_raw, global)]


### PR DESCRIPTION
Old output:

```
❯ target/debug/anda run /home/owen/code/packages/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/update.rhai 
"2.4.0"
```


New output:

```
❯ target/debug/anda run /home/owen/code/packages/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/update.rhai
2.4.0
```