### PR TITLE
feat(andax): add `git_tags` function

### DIFF
--- a/andax/fns/tsunagu.rs
+++ b/andax/fns/tsunagu.rs
@@ -1,4 +1,5 @@
 use crate::{error::AndaxRes, run::rf};
+use core::str::FromStr;
 use git2::Remote;
 use rhai::{
     plugin::{export_module, Dynamic, EvalAltResult, NativeCallContext},
@@ -611,6 +612,45 @@ pub mod ar {
         let v: Value = req.call().ehdl(&ctx)?.into_body().read_json().ehdl(&ctx)?;
         trace!("Got json from {repo} hosted with Forgejo:\n{v}");
         Ok(v[0]["sha"].as_str().unwrap_or("").to_owned())
+    }
+
+    #[rhai_fn(return_raw, global)]
+    pub fn git_tags(ctx: NativeCallContext, url: &str) -> Res<rhai::Array> {
+        const TAGS_PREFIX: &str = "refs/tags/";
+        const RESOLVED_SUFFIX: &str = "^{}";
+
+        let mut tags = rhai::Array::new();
+
+        let req = (AGENT.get(&format!("{url}/info/refs?service=git-upload-pack")))
+            .header("Content-Type", "application/x-git-upload-pack-request");
+
+        let resp = req.call().ehdl(&ctx)?;
+        let is_smart = resp.headers().iter().any(|(key, value)| {
+            key == "Content-Type" && value == "application/x-git-upload-pack-advertisement"
+        });
+        let body: String = resp.into_body().read_to_string().ehdl(&ctx)?;
+
+        for line in body.lines().map(str::trim).filter(|a| !a.is_empty() && !a.starts_with('#')) {
+            let name = if is_smart {
+                let line_length = usize::from_str_radix(&line[..4], 16).unwrap_or(0).checked_sub(1);
+                let Some(line_length) = line_length else {
+                    continue;
+                };
+                line[4..line_length].split_once(' ').map_or("", |(_ref, name)| name)
+            } else {
+                line.split_once('\t').map_or("", |(_ref, name)| name)
+            };
+
+            if !name.starts_with(TAGS_PREFIX) || name.ends_with(RESOLVED_SUFFIX) {
+                continue;
+            }
+
+            if let Ok(tag) = rhai::Dynamic::from_str(&name[TAGS_PREFIX.len()..]) {
+                tags.push(tag);
+            }
+        }
+
+        Ok(tags)
     }
 
     #[rhai_fn(skip)]

--- a/andax/fns/tsunagu.rs
+++ b/andax/fns/tsunagu.rs
@@ -518,6 +518,45 @@ pub mod ar {
         Ok(v[0]["sha"].as_str().unwrap_or("").to_owned())
     }
 
+    #[rhai_fn(return_raw, global)]
+    pub fn git_tag(ctx: NativeCallContext, url: &str) -> Res<String> {
+        const TAGS_PREFIX: &str = "refs/tags/";
+        const RESOLVED_SUFFIX: &str = "^{}";
+
+        let req = (AGENT.get(&format!("{url}/info/refs?service=git-upload-pack")))
+            .header("Content-Type", "application/x-git-upload-pack-request");
+
+        let resp = req.call().ehdl(&ctx)?;
+        let is_smart = resp.headers().iter().any(|(key, value)| { key == "Content-Type" && value == "application/x-git-upload-pack-advertisement" });
+        let body: String = resp.into_body().read_to_string().ehdl(&ctx)?;
+
+        let mut tag_name: Option<String> = None;
+
+        for line in body
+            .lines()
+            .map(str::trim)
+            .filter(|a| !a.is_empty() && !a.starts_with('#'))
+        {
+            let name = if is_smart {
+                let line_length = usize::from_str_radix(&line[..4], 16).unwrap_or(0);
+                if line_length <= 4 {
+                    continue;
+                }
+                line[4..line_length-1].split_once(' ').unwrap_or(("", "")).1
+            } else {
+                line.split_once('\t').unwrap_or(("", "")).1
+            };
+
+            if !name.starts_with(TAGS_PREFIX) || name.ends_with(RESOLVED_SUFFIX) {
+                continue;
+            }
+
+            tag_name = Some(name[TAGS_PREFIX.len()..].to_owned());
+        }
+
+        Ok(tag_name.as_deref().unwrap_or("").to_owned())
+    }
+
     #[rhai_fn(skip)]
     pub fn internal_env(key: &str) -> Res<String> {
         trace!("env(`{key}`) = {:?}", std::env::var(key));

--- a/tests/test.rhai
+++ b/tests/test.rhai
@@ -48,6 +48,8 @@ print(env("PATH"));
 // print(tangled_commit("tangled.org/core"));
 // print(tangled_rawfile("tangled.org/core", "master", "docs/DOCS.md"));
 
+// print(git_tags("https://github.com/FyraLabs/anda"));
+
 let obj = #{
     "a": 1,
     "b": 2 ,


### PR DESCRIPTION
Implements a new function `git_tags` which uses the git HTTP protocol to return a list of all tags

The protocol is documented here: https://git-scm.com/docs/gitprotocol-http/2.43.0

Both the dumb and smart HTTP responses are supported to cover every possible git server.

Because git tags are not sorted and projects may choose to use arbitrary tag styling (i.e. `-rc`, `-alpha`, `-beta`, etc.) this function returns a list to then check over in an update script.