### PR TITLE
feat: add `no_network` build option

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -312,6 +312,8 @@ pub async fn build_project(
                 }
             }
         }
+
+        rpm_opts.no_network = rbopts.no_network;
     }
     let mut arts = Artifacts::new();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -148,6 +148,10 @@ pub struct RpmOpts {
     /// RPM: Whether to clean up a mock chroot and when
     #[clap(long)]
     pub mock_no_cleanup: Option<NoMockCleanup>,
+
+    /// RPM: disable network access in the mock chroot
+    #[clap(long, action)]
+    pub no_network: bool,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/src/rpm_spec.rs
+++ b/src/rpm_spec.rs
@@ -52,6 +52,8 @@ pub struct RPMOptions {
     /// Cleanup Options (mock)
     pub no_cleanup_before: bool,
     pub no_cleanup_after: bool,
+    /// Disable networking (mock)
+    pub no_network: bool,
 }
 
 impl RPMOptions {
@@ -158,6 +160,7 @@ impl RPMBuilder {
             mock.plugin_opts(take(&mut options.plugin_opts));
             mock.enable_no_cleanup_before(options.no_cleanup_before);
             mock.enable_no_cleanup_after(options.no_cleanup_after);
+            mock.enable_no_network(options.no_network);
 
             mock.build(spec).await
         } else {
@@ -269,6 +272,7 @@ pub struct MockBackend {
     args: Vec<String>,
     no_cleanup_before: bool,
     no_cleanup_after: bool,
+    no_network: bool,
 }
 
 impl RPMExtraOptions for MockBackend {
@@ -343,6 +347,10 @@ impl MockBackend {
         self.no_cleanup_after = enable;
     }
 
+    pub const fn enable_no_network(&mut self, enable: bool) {
+        self.no_network = enable;
+    }
+
     pub fn target(&mut self, target: Option<String>) {
         self.target = target;
     }
@@ -402,6 +410,10 @@ impl MockBackend {
             cmd.arg("--no-cleanup-after");
         }
 
+        if !self.no_network {
+            cmd.arg("--enable-network");
+        }
+
         cmd
     }
 }
@@ -454,7 +466,7 @@ impl RPMSpecBackend for MockBackend {
     async fn build_rpm(&self, spec: &Path) -> Result<Vec<PathBuf>> {
         let mut cmd = self.mock();
         let tmp = tempfile::Builder::new().prefix("anda-rpm").tempdir()?;
-        cmd.arg("--rebuild").arg(spec).arg("--enable-network").arg("--resultdir").arg(tmp.path());
+        cmd.arg("--rebuild").arg(spec).arg("--resultdir").arg(tmp.path());
 
         cmd.log().await?;
 


### PR DESCRIPTION
The built-in mock flags always enable networking but it may sometimes be useful to build offline so I added this flag.